### PR TITLE
Feature/event

### DIFF
--- a/Assets/Cardinal/Scripts/Cardinal.cs
+++ b/Assets/Cardinal/Scripts/Cardinal.cs
@@ -329,8 +329,11 @@ public class Cardinal : MonoBehaviour
         }
 
         GameBalance balance = InGameManager.Instance.Balance;
+        bool guaranteedSuccess = InGameManager.Instance.EventManager != null &&
+            InGameManager.Instance.EventManager.TryConsumeGuaranteedPrayerOrSpeech(this);
+        bool rolledSuccess = Random.value < balance.PraySuccessChance;
 
-        if (Random.value < balance.PraySuccessChance)
+        if (guaranteedSuccess || rolledSuccess)
         {
             ChangePiety(balance.PraySuccessDeltaPiety);
             ChangeHp(balance.PraySuccessDeltaHp + prayDeltaHpEvent);
@@ -360,6 +363,9 @@ public class Cardinal : MonoBehaviour
         }
 
         GameBalance balance = InGameManager.Instance.Balance;
+        bool guaranteedSuccess = InGameManager.Instance.EventManager != null &&
+            InGameManager.Instance.EventManager.TryConsumeGuaranteedPrayerOrSpeech(this);
+        bool rolledSuccess = Random.value < balance.SpeechSuccessChance;
 
         Animation_Controller anim = GetComponent<Animation_Controller>();
         if (anim == null)
@@ -367,7 +373,7 @@ public class Cardinal : MonoBehaviour
             anim = GetComponentInChildren<Animation_Controller>();
         }
 
-        if (Random.value < balance.SpeechSuccessChance)
+        if (guaranteedSuccess || rolledSuccess)
         {
             if (anim != null)
             {

--- a/Assets/Cardinal/Scripts/Cardinal.cs
+++ b/Assets/Cardinal/Scripts/Cardinal.cs
@@ -25,7 +25,8 @@ public class Cardinal : MonoBehaviour
     private List<Item> items;
     private NavMeshAgent agent;
     private bool isKnockedOut = false;
-    private bool hasMinHpOneEffect = false;
+    private readonly HashSet<string> minHpOneEffectSources = new HashSet<string>();
+    private GameContext subscribedGameContext;
     private bool isInitialized = false;
     private Coroutine indicatorRestoreCoroutine;
 
@@ -50,6 +51,7 @@ public class Cardinal : MonoBehaviour
 
     void Start()
     {
+        SubscribeToGameContext();
         if (!isInitialized)
         {
             InitCardinal();
@@ -104,6 +106,7 @@ public class Cardinal : MonoBehaviour
 
     void OnEnable()
     {
+        SubscribeToGameContext();
         if (items != null)
         {
             foreach (var item in items)
@@ -114,6 +117,11 @@ public class Cardinal : MonoBehaviour
                 }
             }
         }
+    }
+
+    void OnDisable()
+    {
+        UnsubscribeFromGameContext();
     }
 
     private void ApplyBalanceDefaults()
@@ -131,6 +139,7 @@ public class Cardinal : MonoBehaviour
         speedMultiplier = 1f;
         prayDeltaHpEvent = 0f;
         isKnockedOut = false;
+        minHpOneEffectSources.Clear();
 
         if (agent != null)
         {
@@ -164,6 +173,8 @@ public class Cardinal : MonoBehaviour
     public CardinalSaveData CaptureSaveData(int index)
     {
         StateController stateController = GetComponent<StateController>();
+        List<string> savedMinHpSources = new List<string>(minHpOneEffectSources);
+        savedMinHpSources.Sort(System.StringComparer.Ordinal);
 
         return new CardinalSaveData
         {
@@ -176,6 +187,7 @@ public class Cardinal : MonoBehaviour
             piety = GetBalanceFallback(piety, balance => balance.InitialPiety),
             hpDrainMultiplier = hpDrainMultiplier,
             prayDeltaHpEvent = prayDeltaHpEvent,
+            minHpOneEffectSources = savedMinHpSources,
             isKnockedOut = isKnockedOut,
             isSchemer = stateController != null && stateController.IsSchemer,
             isConClaving = stateController != null && stateController.ConClaving,
@@ -194,6 +206,14 @@ public class Cardinal : MonoBehaviour
         piety = saveData.piety;
         hpDrainMultiplier = saveData.hpDrainMultiplier;
         prayDeltaHpEvent = saveData.prayDeltaHpEvent;
+        minHpOneEffectSources.Clear();
+        if (saveData.minHpOneEffectSources != null)
+        {
+            foreach (string sourceId in saveData.minHpOneEffectSources)
+            {
+                if (!string.IsNullOrWhiteSpace(sourceId)) minHpOneEffectSources.Add(sourceId);
+            }
+        }
         isKnockedOut = saveData.isKnockedOut;
         isInitialized = true;
 
@@ -268,14 +288,22 @@ public class Cardinal : MonoBehaviour
 
     public void SetMinHpOneEffect(bool active)
     {
-        hasMinHpOneEffect = active;
+        SetMinHpOneEffect("Legacy", active);
+    }
+
+    public void SetMinHpOneEffect(string sourceId, bool active)
+    {
+        if (string.IsNullOrWhiteSpace(sourceId)) return;
+
+        if (active) minHpOneEffectSources.Add(sourceId);
+        else minHpOneEffectSources.Remove(sourceId);
     }
 
     public void ChangeHp(float delta)
     {
         float nextHp = hp + delta;
 
-        if (hasMinHpOneEffect && delta < 0f)
+        if (minHpOneEffectSources.Count > 0 && delta < 0f)
         {
             hp = Mathf.Clamp(nextHp, 1f, 100f);
         }
@@ -293,6 +321,31 @@ public class Cardinal : MonoBehaviour
     public void ChangePiety(float delta)
     {
         piety = Mathf.Clamp(piety + delta, 0f, 100f);
+    }
+
+    private void SubscribeToGameContext()
+    {
+        GameContext context = InGameManager.Instance != null ? InGameManager.Instance.Context : null;
+        if (context == null || subscribedGameContext == context) return;
+
+        UnsubscribeFromGameContext();
+        subscribedGameContext = context;
+        subscribedGameContext.OnGameContextEvent += HandleGameContextEvent;
+    }
+
+    private void UnsubscribeFromGameContext()
+    {
+        if (subscribedGameContext == null) return;
+        subscribedGameContext.OnGameContextEvent -= HandleGameContextEvent;
+        subscribedGameContext = null;
+    }
+
+    private void HandleGameContextEvent(GameContext.GameContextEvent eventType)
+    {
+        if (eventType == GameContext.GameContextEvent.ConclaveEnd)
+        {
+            minHpOneEffectSources.Clear();
+        }
     }
 
     public void AddPassiveItem(Item item)

--- a/Assets/Core/Scripts/SaveModel.cs
+++ b/Assets/Core/Scripts/SaveModel.cs
@@ -234,6 +234,7 @@ public class CardinalSaveData
     public float piety;
     public float hpDrainMultiplier = 1f;
     public float prayDeltaHpEvent;
+    public List<string> minHpOneEffectSources = new List<string>();
     public bool isKnockedOut;
     public bool isSchemer;
     public bool isConClaving;

--- a/Assets/Core/Scripts/SaveModel.cs
+++ b/Assets/Core/Scripts/SaveModel.cs
@@ -261,6 +261,10 @@ public class ItemSaveData
 public class EventManagerSaveData
 {
     public List<EventRecordSaveData> records = new List<EventRecordSaveData>();
+    public List<EventChoiceSaveData> choices = new List<EventChoiceSaveData>();
+    public List<EventPlotDamageBonusSaveData> plotDamageBonuses = new List<EventPlotDamageBonusSaveData>();
+    public bool guaranteeNextPrayerOrSpeech;
+    public bool freePlotPietyForCurrentConclave;
 }
 
 [Serializable]
@@ -268,6 +272,21 @@ public class EventRecordSaveData
 {
     public string eventId;
     public int appearCount;
+}
+
+[Serializable]
+public class EventChoiceSaveData
+{
+    public string eventId;
+    public int optionIndex;
+    public bool succeeded;
+}
+
+[Serializable]
+public class EventPlotDamageBonusSaveData
+{
+    public int candidateNumber;
+    public float bonus;
 }
 
 [Serializable]

--- a/Assets/Event/EventsScripts/E11100.cs
+++ b/Assets/Event/EventsScripts/E11100.cs
@@ -3,6 +3,22 @@ using UnityEngine;
 [CreateAssetMenu(fileName = "E11100", menuName = "Events/큰일났다!")]
 public class E11100 : Event
 {
+    void OnEnable()
+    {
+        if (!string.IsNullOrWhiteSpace(eventID)) return;
+
+        EventManager manager = InGameManager.Instance != null ? InGameManager.Instance.EventManager : null;
+        Event definition = manager != null ? manager.GetEventById("E11100") : null;
+        if (definition != null && definition != this)
+        {
+            CopyDefinitionFrom(definition);
+        }
+        else
+        {
+            Reset();
+        }
+    }
+
     void Reset()
     {
         eventID = "E11100";
@@ -34,12 +50,12 @@ public class E11100 : Event
         performer.ChangeInfluence(40f);
         performer.hpDrainMultiplier *= 2f;
 
-        return true;
+        return FinishChoice(1, true);
     }
 
 
     public override bool OnChoiceOption2(Cardinal performer)
     {
-        return true;
+        return FinishChoice(2, true);
     }
 }

--- a/Assets/Event/EventsScripts/E11200.cs
+++ b/Assets/Event/EventsScripts/E11200.cs
@@ -36,13 +36,13 @@ public class E11200 : Event
 
         
 
-        return true;
+        return FinishChoice(1, true);
     }
 
 
     public override bool OnChoiceOption2(Cardinal performer)
     {
         if(!CanChoiceOption2(performer)) return false;
-        return true;
+        return FinishChoice(2, true);
     }
 }

--- a/Assets/Event/EventsScripts/E11300.cs
+++ b/Assets/Event/EventsScripts/E11300.cs
@@ -35,12 +35,12 @@ public class E11300 : Event
 
         
 
-        return true;
+        return FinishChoice(1, true);
     }
 
 
     public override bool OnChoiceOption2(Cardinal performer)
     {
-        return true;
+        return FinishChoice(2, true);
     }
 }

--- a/Assets/Event/EventsScripts/E12100.cs
+++ b/Assets/Event/EventsScripts/E12100.cs
@@ -1,4 +1,6 @@
+using System.Collections;
 using UnityEngine;
+using UnityEngine.UI;
 
 [CreateAssetMenu(fileName = "E12100", menuName = "Events/태양의 눈")]
 public class E12100 : Event
@@ -53,7 +55,47 @@ public class E12100 : Event
         else
         {
             performer.ChangeHp(-20f);
+            performer.StartCoroutine(PlayWhiteFlash());
             return false;
         }
+    }
+
+    private static IEnumerator PlayWhiteFlash()
+    {
+        GameObject overlay = new GameObject("E12100_WhiteFlash", typeof(Canvas));
+        Canvas canvas = overlay.GetComponent<Canvas>();
+        canvas.renderMode = RenderMode.ScreenSpaceOverlay;
+        canvas.sortingOrder = short.MaxValue;
+
+        GameObject imageObject = new GameObject(
+            "White",
+            typeof(RectTransform),
+            typeof(CanvasRenderer),
+            typeof(Image));
+        imageObject.transform.SetParent(overlay.transform, false);
+
+        RectTransform rectTransform = imageObject.GetComponent<RectTransform>();
+        rectTransform.anchorMin = Vector2.zero;
+        rectTransform.anchorMax = Vector2.one;
+        rectTransform.offsetMin = Vector2.zero;
+        rectTransform.offsetMax = Vector2.zero;
+
+        Image image = imageObject.GetComponent<Image>();
+        image.color = Color.white;
+        image.raycastTarget = false;
+
+        const float holdDuration = 0.12f;
+        const float fadeDuration = 0.45f;
+        yield return new WaitForSecondsRealtime(holdDuration);
+
+        float elapsed = 0f;
+        while (elapsed < fadeDuration)
+        {
+            elapsed += Time.unscaledDeltaTime;
+            image.color = new Color(1f, 1f, 1f, 1f - Mathf.Clamp01(elapsed / fadeDuration));
+            yield return null;
+        }
+
+        Destroy(overlay);
     }
 }

--- a/Assets/Event/EventsScripts/E12200.cs
+++ b/Assets/Event/EventsScripts/E12200.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using UnityEngine;
 
 [CreateAssetMenu(fileName = "E12200", menuName = "Events/태양의 발")]
@@ -48,16 +49,34 @@ public class E12200 : Event
         if(Random.value <= option2Chance)
         {
             performer.ChangeHp(-10f);
-            // 이동속도증가로직
+            performer.StartCoroutine(Co_ApplySpeedUntilConclaveEnd(performer, 0.3f));
 
-            return true;
+            return FinishChoice(2, true);
         }
         else
         {
             performer.ChangeHp(-10f);
-
-            // 이동속도감소로직
-            return false;
+            performer.StartCoroutine(Co_ApplySpeedUntilConclaveEnd(performer, -0.2f));
+            return FinishChoice(2, false);
         }
+    }
+
+    private IEnumerator Co_ApplySpeedUntilConclaveEnd(Cardinal target, float delta)
+    {
+        if(target == null || InGameManager.Instance == null || InGameManager.Instance.Context == null) yield break;
+
+        bool isEnded = false;
+        GameContext context = InGameManager.Instance.Context;
+
+        void OnContextEvent(GameContext.GameContextEvent eventType)
+        {
+            if(eventType == GameContext.GameContextEvent.ConclaveEnd) isEnded = true;
+        }
+
+        target.ChangeSpeed(delta);
+        context.OnGameContextEvent += OnContextEvent;
+        yield return new WaitUntil(() => isEnded || target == null);
+        if(target != null) target.ChangeSpeed(-delta);
+        context.OnGameContextEvent -= OnContextEvent;
     }
 }

--- a/Assets/Event/EventsScripts/E12300.cs
+++ b/Assets/Event/EventsScripts/E12300.cs
@@ -34,14 +34,14 @@ public class E12300 : Event
         {  // 성공했을 때 로직
             performer.ChangeHp(10f);
 
-            return true;
+            return FinishChoice(1, true);
         }
         else
         {  // 실패했을 때 로직
             performer.ChangeHp(-20f);
             performer.ChangePiety(20f);
 
-            return false;
+            return FinishChoice(1, false);
         }
     }
 
@@ -52,16 +52,16 @@ public class E12300 : Event
 
         if(Random.value <= option2Chance)
         {  // 성공했을 때 로직
-            performer.ChangeHp(10f);
+            performer.ChangeHp(20f);
 
-            return true;
+            return FinishChoice(2, true);
         }
         else
         {  // 실패했을 때 로직
             performer.ChangeHp(-20f);
             performer.ChangePiety(20f);
 
-            return false;
+            return FinishChoice(2, false);
         }
     }
 }

--- a/Assets/Event/EventsScripts/E20000.cs
+++ b/Assets/Event/EventsScripts/E20000.cs
@@ -35,13 +35,13 @@ public class E20000 : Event
         {  // 성공했을 때 로직
 
 
-            return true;
+            return FinishChoice(1, true);
         }
         else
         {  // 실패했을 때 로직
             
 
-            return false;
+            return FinishChoice(1, false);
         }
     }
 
@@ -54,13 +54,13 @@ public class E20000 : Event
         {  // 성공했을 때 로직
 
 
-            return true;
+            return FinishChoice(2, true);
         }
         else
         {  // 실패했을 때 로직
             
 
-            return false;
+            return FinishChoice(2, false);
         }
     }
 }

--- a/Assets/Event/EventsScripts/E21000.cs
+++ b/Assets/Event/EventsScripts/E21000.cs
@@ -36,13 +36,13 @@ public class E21000 : Event
             performer.ChangePiety(10f);
             performer.ChangeInfluence(-10f);
 
-            return true;
+            return FinishChoice(1, true);
         }
         else
         {  // 실패했을 때 로직
             
 
-            return false;
+            return FinishChoice(1, false);
         }
     }
 
@@ -55,13 +55,13 @@ public class E21000 : Event
         {  // 성공했을 때 로직
             performer.ChangeInfluence(10f);
 
-            return true;
+            return FinishChoice(2, true);
         }
         else
         {  // 실패했을 때 로직
             
 
-            return false;
+            return FinishChoice(2, false);
         }
     }
 }

--- a/Assets/Event/EventsScripts/E21100.cs
+++ b/Assets/Event/EventsScripts/E21100.cs
@@ -1,5 +1,4 @@
 using UnityEngine;
-using System.Linq;
 
 [CreateAssetMenu(fileName = "E21100", menuName = "Events/신앙인가, 과학인가?")]
 public class E21100 : Event
@@ -34,19 +33,17 @@ public class E21100 : Event
         if(Random.value <= option1Chance)
         {  // 성공했을 때 로직
             performer.ChangeInfluence(10f);
-            var aiCardinals = CardinalManager.Instance.GetAICardinlas();
+            Cardinal candidate1 = GetCandidate(1);
+            if(candidate1 != null) candidate1.ChangeInfluence(10f);
+            InGameManager.Instance.EventManager.SetPlotDamageBonus(2, 10f);
 
-            aiCardinals[0].ChangeInfluence(10f);
-
-            // 공작 피해 증폭로직
-
-            return true;
+            return FinishChoice(1, true);
         }
         else
         {  // 실패했을 때 로직
             
 
-            return false;
+            return FinishChoice(1, false);
         }
     }
 
@@ -58,19 +55,18 @@ public class E21100 : Event
         if(Random.value <= option2Chance)
         {  // 성공했을 때 로직
             performer.ChangeInfluence(10f);
-            var aiCardinals = CardinalManager.Instance.Cardinals.Where(c => !c.CompareTag("Player")).ToList();
-
-            aiCardinals[1].ChangeInfluence(10f);
+            Cardinal candidate2 = GetCandidate(2);
+            if(candidate2 != null) candidate2.ChangeInfluence(10f);
 
             performer.prayDeltaHpEvent = 5f;
 
-            return true;
+            return FinishChoice(2, true);
         }
         else
         {  // 실패했을 때 로직
             
 
-            return false;
+            return FinishChoice(2, false);
         }
     }
 }

--- a/Assets/Event/EventsScripts/E21101.cs
+++ b/Assets/Event/EventsScripts/E21101.cs
@@ -30,16 +30,17 @@ public class E21101 : Event
     {
         if(!CanChoiceOption1(performer)) return false;
 
-        var aiCardinals = CardinalManager.Instance.GetAICardinlas();
-        if(aiCardinals[0].Influence > aiCardinals[1].Influence)
+        Cardinal candidate1 = GetCandidate(1);
+        Cardinal candidate2 = GetCandidate(2);
+        if(candidate1 != null && candidate2 != null && candidate1.Influence > candidate2.Influence)
         {
-            return true;
+            return FinishChoiceWithEnding(1, EndingType.Crusade);
         }
         else
         {  // 실패했을 때 로직
-            
-
-            return false;
+            EliminateCandidate(1);
+            EliminateCandidate(2);
+            return FinishChoice(1, false);
         }
     }
 
@@ -52,13 +53,13 @@ public class E21101 : Event
         {  // 성공했을 때 로직
 
 
-            return true;
+            return FinishChoice(2, true);
         }
         else
         {  // 실패했을 때 로직
             
 
-            return false;
+            return FinishChoice(2, false);
         }
     }
 }

--- a/Assets/Event/EventsScripts/E30000.cs
+++ b/Assets/Event/EventsScripts/E30000.cs
@@ -35,13 +35,13 @@ public class E30000 : Event
         {  // 성공했을 때 로직
 
 
-            return true;
+            return FinishChoice(1, true);
         }
         else
         {  // 실패했을 때 로직
             
 
-            return false;
+            return FinishChoice(1, false);
         }
     }
 
@@ -55,16 +55,12 @@ public class E30000 : Event
             performer.ChangeHp(30);
             InGameManager.Instance.Context.ChangeRemainingTime(-20f);
 
-            // 콘클라베 즉시종료 로직인데 문제가 발생할가능성있음
-            InGameManager.Instance.Context.ChangeRemainingTime(-99999f);
-
-            return true;
+            return FinishChoice(2, true);
         }
         else
         {  // 실패했을 때 로직
-            
-
-            return false;
+            InGameManager.Instance.Context.ChangeRemainingTime(-99999f);
+            return FinishChoice(2, false);
         }
     }
 }

--- a/Assets/Event/EventsScripts/E31000.cs
+++ b/Assets/Event/EventsScripts/E31000.cs
@@ -32,16 +32,17 @@ public class E31000 : Event
 
         if(Random.value <= option1Chance)
         {  // 성공했을 때 로직
-            var aiCardinals = CardinalManager.Instance.GetAICardinlas();
-            aiCardinals[2].ChangeInfluence(20f);
+            Cardinal candidate3 = GetCandidate(3);
+            if(candidate3 != null) candidate3.ChangeInfluence(20f);
+            InGameManager.Instance.EventManager.SetPlotDamageBonus(2, 15f);
 
-            return true;
+            return FinishChoice(1, true);
         }
         else
         {  // 실패했을 때 로직
             
 
-            return false;
+            return FinishChoice(1, false);
         }
     }
 
@@ -52,17 +53,18 @@ public class E31000 : Event
 
         if(Random.value <= option2Chance)
         {  // 성공했을 때 로직
-            var aiCardinals = CardinalManager.Instance.GetAICardinlas();
-            aiCardinals[1].ChangeInfluence(20f);
+            Cardinal candidate2 = GetCandidate(2);
+            if(candidate2 != null) candidate2.ChangeInfluence(20f);
+            InGameManager.Instance.EventManager.SetPlotDamageBonus(3, 20f);
 
-            return true;
+            return FinishChoice(2, true);
         }
         else
         {  // 실패했을 때 로직
             performer.ChangeInfluence(-30f);
             performer.ChangeHp(-20f);
 
-            return false;
+            return FinishChoice(2, false);
         }
     }
 }

--- a/Assets/Event/EventsScripts/E31100.cs
+++ b/Assets/Event/EventsScripts/E31100.cs
@@ -7,7 +7,7 @@ public class E31100 : Event
     {
         eventID = "E31100";
         eventName = "반란모의";
-        maxAppear = 1;
+        maxAppear = 4;
 
         eventWeightBase = 20f;
         eventWeightMultiplier = 0f;
@@ -36,13 +36,13 @@ public class E31100 : Event
             performer.ChangePiety(40f);
             performer.ChangeInfluence(15f);
 
-            return true;
+            return FinishChoice(1, true);
         }
         else
         {  // 실패했을 때 로직
             
 
-            return false;
+            return FinishChoice(1, false);
         }
     }
 
@@ -55,13 +55,13 @@ public class E31100 : Event
         {  // 성공했을 때 로직
 
 
-            return true;
+            return FinishChoiceWithEnding(2, EndingType.Crusade);
         }
         else
         {  // 실패했을 때 로직
             
 
-            return false;
+            return FinishChoice(2, false);
         }
     }
 }

--- a/Assets/Event/EventsScripts/E31101.cs
+++ b/Assets/Event/EventsScripts/E31101.cs
@@ -35,13 +35,13 @@ public class E31101 : Event
         {  // 성공했을 때 로직
 
 
-            return true;
+            return FinishChoiceWithEnding(1, EndingType.GreatSage);
         }
         else
         {  // 실패했을 때 로직
             
 
-            return false;
+            return FinishChoice(1, false);
         }
     }
 
@@ -54,13 +54,13 @@ public class E31101 : Event
         {  // 성공했을 때 로직
 
 
-            return true;
+            return FinishChoiceWithEnding(2, EndingType.PolarBear);
         }
         else
         {  // 실패했을 때 로직
             
 
-            return false;
+            return FinishChoice(2, false);
         }
     }
 }

--- a/Assets/Event/EventsScripts/E31200.cs
+++ b/Assets/Event/EventsScripts/E31200.cs
@@ -34,13 +34,13 @@ public class E31200 : Event
         {  // 성공했을 때 로직
 
 
-            return true;
+            return FinishChoice(1, true);
         }
         else
         {  // 실패했을 때 로직
             
 
-            return false;
+            return FinishChoice(1, false);
         }
     }
 
@@ -51,15 +51,17 @@ public class E31200 : Event
 
         if(Random.value <= option2Chance)
         {  // 성공했을 때 로직
+            SetCandidateStats(2, 60f, 60f, 60f);
 
-
-            return true;
+            // TODO(태양만세 엔딩): 후보 2가 최종 당선될 때 전용 엔딩으로 전환한다.
+            // EndingType과 엔딩 컷신이 아직 없으므로 여기서는 부활/분기 기록까지만 수행한다.
+            return FinishChoice(2, true);
         }
         else
         {  // 실패했을 때 로직
             
 
-            return false;
+            return FinishChoice(2, false);
         }
     }
 }

--- a/Assets/Event/EventsScripts/E31210.cs
+++ b/Assets/Event/EventsScripts/E31210.cs
@@ -1,4 +1,3 @@
-using JetBrains.Annotations;
 using UnityEngine;
 
 [CreateAssetMenu(fileName = "E31210", menuName = "Events/태양 만세!")]
@@ -37,16 +36,16 @@ public class E31210 : Event
             performer.ChangeHp(-20f);
             performer.ChangeInfluence(20f);
 
-            var aiCardinals = CardinalManager.Instance.GetAICardinlas();
-            aiCardinals[2].ChangeInfluence(-30f);
+            Cardinal candidate3 = GetCandidate(3);
+            if(candidate3 != null) candidate3.ChangeInfluence(-30f);
 
-            return true;
+            return FinishChoice(1, true);
         }
         else
         {  // 실패했을 때 로직
             
 
-            return false;
+            return FinishChoice(1, false);
         }
     }
 
@@ -56,8 +55,8 @@ public class E31210 : Event
 
         if(Random.value <= option2Chance)
         {  // 성공했을 때 로직
-            var aiCardinals = CardinalManager.Instance.GetAICardinlas();
-            aiCardinals[2].ChangeInfluence(-50f);
+            Cardinal candidate3 = GetCandidate(3);
+            if(candidate3 != null) candidate3.ChangeInfluence(-50f);
 
             var cardinals = CardinalManager.Instance.Cardinals;
             foreach(var c in cardinals)
@@ -65,16 +64,19 @@ public class E31210 : Event
                 c.ChangeHp(-20f);
             }
 
-            return true;
+            return FinishChoice(2, true);
         }
         else
         {  // 실패했을 때 로직
-            // 후보2 탈락로직필요
-            var aiCardinals = CardinalManager.Instance.GetAICardinlas();
-            aiCardinals[2].ChangeHp(-40f);
-            aiCardinals[2].ChangeInfluence(50f);
+            EliminateCandidate(2);
+            Cardinal candidate3 = GetCandidate(3);
+            if(candidate3 != null)
+            {
+                candidate3.ChangeHp(-40f);
+                candidate3.ChangeInfluence(50f);
+            }
 
-            return false;
+            return FinishChoice(2, false);
         }
     }
 }

--- a/Assets/Event/EventsScripts/E31211.cs
+++ b/Assets/Event/EventsScripts/E31211.cs
@@ -34,13 +34,13 @@ public class E31211 : Event
         {  // 성공했을 때 로직
 
 
-            return true;
+            return FinishChoiceWithEnding(1, EndingType.Crusade);
         }
         else
         {  // 실패했을 때 로직
             
 
-            return false;
+            return FinishChoice(1, false);
         }
     }
 
@@ -53,13 +53,13 @@ public class E31211 : Event
         {  // 성공했을 때 로직
 
 
-            return true;
+            return FinishChoice(2, true);
         }
         else
         {  // 실패했을 때 로직
             
 
-            return false;
+            return FinishChoice(2, false);
         }
     }
 }

--- a/Assets/Event/EventsScripts/E31212.cs
+++ b/Assets/Event/EventsScripts/E31212.cs
@@ -45,15 +45,13 @@ public class E31212 : Event
 
         if(Random.value <= option1Chance)
         {  // 성공했을 때 로직
-            // 승천 엔딩 처리 필요
-
-            return true;
+            return FinishChoiceWithEnding(1, EndingType.Ascension);
         }
         else
         {  // 실패했을 때 로직
             GiveItemById("I013");
 
-            return false;
+            return FinishChoice(1, false);
         }
     }
 
@@ -71,13 +69,13 @@ public class E31212 : Event
                 option2SuccessDescription = $"오... 좋은 아이템을 찾았다!\n\n{item.itemName} 획득!";
             }
 
-            return true;
+            return FinishChoice(2, true);
         }
         else
         {  // 실패했을 때 로직
             
 
-            return false;
+            return FinishChoice(2, false);
         }
     }
 

--- a/Assets/Event/EventsScripts/E31213.cs
+++ b/Assets/Event/EventsScripts/E31213.cs
@@ -45,13 +45,13 @@ public class E31213 : Event
             var aiCardinals = CardinalManager.Instance.GetAICardinlas();
             aiCardinals[0].ChangeInfluence(30f);
 
-            return true;
+            return FinishChoice(1, true);
         }
         else
         {  // 실패했을 때 로직
             
 
-            return false;
+            return FinishChoice(1, false);
         }
     }
 
@@ -67,13 +67,13 @@ public class E31213 : Event
             var aiCardinals = CardinalManager.Instance.GetAICardinlas();
             aiCardinals[2].ChangeInfluence(30f);
 
-            return true;
+            return FinishChoice(2, true);
         }
         else
         {  // 실패했을 때 로직
             
 
-            return false;
+            return FinishChoice(2, false);
         }
     }
 }

--- a/Assets/Event/EventsScripts/E32000.cs
+++ b/Assets/Event/EventsScripts/E32000.cs
@@ -55,20 +55,20 @@ public class E32000 : Event
                 aiCardinals[1].ChangeHp(-100f);
             }
 
-            return true;
+            return FinishChoice(1, true);
         }
         else
         {  // 실패했을 때 로직
             EndCurrentConclave();
 
-            // 후보 2 탈락 처리 필요
+            EliminateCandidate(2);
             foreach(var cardinal in GetPlayerAndMainCandidates(performer))
             {
                 cardinal.ChangeHp(-20f);
                 cardinal.ChangeInfluence(-30f);
             }
 
-            return false;
+            return FinishChoice(1, false);
         }
     }
 
@@ -86,13 +86,13 @@ public class E32000 : Event
                 cardinal.ChangePiety(-40f);
             }
 
-            return true;
+            return FinishChoice(2, true);
         }
         else
         {  // 실패했을 때 로직
             
 
-            return false;
+            return FinishChoice(2, false);
         }
     }
 

--- a/Assets/Event/EventsScripts/E32001.cs
+++ b/Assets/Event/EventsScripts/E32001.cs
@@ -49,13 +49,13 @@ public class E32001 : Event
             performer.ChangePiety(20f);
             performer.ChangeInfluence(15f);
 
-            return true;
+            return FinishChoice(1, true);
         }
         else
         {  // 실패했을 때 로직
             
 
-            return false;
+            return FinishChoice(1, false);
         }
     }
 
@@ -66,15 +66,13 @@ public class E32001 : Event
 
         if(Random.value <= option2Chance)
         {  // 성공했을 때 로직
-            // 성전 엔딩 처리 필요
-
-            return true;
+            return FinishChoiceWithEnding(2, EndingType.Crusade);
         }
         else
         {  // 실패했을 때 로직
             
 
-            return false;
+            return FinishChoice(2, false);
         }
     }
 }

--- a/Assets/Event/EventsScripts/E32002.cs
+++ b/Assets/Event/EventsScripts/E32002.cs
@@ -46,16 +46,13 @@ public class E32002 : Event
         {  // 성공했을 때 로직
             performer.ChangePiety(-10f);
 
-            // 연설 시마다 후보 1 정치력 5 증가 처리 필요
-            // 후보 3 탈락 + 후보 1 당선 시 성전 엔딩 처리 필요
-
-            return true;
+            return FinishChoiceWithEnding(1, EndingType.Crusade);
         }
         else
         {  // 실패했을 때 로직
             
 
-            return false;
+            return FinishChoice(1, false);
         }
     }
 
@@ -68,16 +65,13 @@ public class E32002 : Event
         {  // 성공했을 때 로직
             performer.ChangeInfluence(10f);
 
-            // 연설 시마다 후보 3 정치력 5 증가 처리 필요
-            // 외교 승리 엔딩 조건 확인 필요: 설명은 후보 1 탈락 + 후보 3 당선이나, 효과 문구는 후보 3 탈락 + 후보 1 당선으로 적혀 있음
-
-            return true;
+            return FinishChoiceWithEnding(2, EndingType.DiplomaticVictory);
         }
         else
         {  // 실패했을 때 로직
             
 
-            return false;
+            return FinishChoice(2, false);
         }
     }
 }

--- a/Assets/Event/EventsScripts/E40500.cs
+++ b/Assets/Event/EventsScripts/E40500.cs
@@ -60,7 +60,7 @@ public class E40500 : Event
 
         if(Random.value <= option2Chance)
         {
-            // 이번 썬ㅡ클라베에서 기도/연설 이후 남은 시간 5초 추가 감소 처리 필요
+            InGameManager.Instance.EventManager.SetPrayerSpeechTimePenalty(5f);
             return true;
         }
 

--- a/Assets/Event/EventsScripts/E40500.cs
+++ b/Assets/Event/EventsScripts/E40500.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using UnityEngine;
 
 [CreateAssetMenu(fileName = "E40500", menuName = "Events/주화입마")]
@@ -60,11 +61,49 @@ public class E40500 : Event
 
         if(Random.value <= option2Chance)
         {
-            InGameManager.Instance.EventManager.SetPrayerSpeechTimePenalty(5f);
+            performer.StartCoroutine(ApplyPrayerSpeechTimePenalty());
             return true;
         }
 
         performer.ChangeInfluence(5f);
         return false;
+    }
+
+    private static IEnumerator ApplyPrayerSpeechTimePenalty()
+    {
+        ActionRecordManager records = ActionRecordManager.Instance;
+        GameContext context = InGameManager.Instance != null ? InGameManager.Instance.Context : null;
+        if (records == null || context == null) yield break;
+
+        int previousActionCount = records.GetCurrentPrayCount() + records.GetCurrentSpeechCount();
+        bool conclaveEnded = false;
+        System.Action<GameContext.GameContextEvent> onContextEvent = eventType =>
+        {
+            if (eventType == GameContext.GameContextEvent.ConclaveEnd)
+            {
+                conclaveEnded = true;
+            }
+        };
+
+        context.OnGameContextEvent += onContextEvent;
+        try
+        {
+            while (!conclaveEnded)
+            {
+                int currentActionCount = records.GetCurrentPrayCount() + records.GetCurrentSpeechCount();
+                int completedActionCount = Mathf.Max(0, currentActionCount - previousActionCount);
+                if (completedActionCount > 0)
+                {
+                    context.ChangeRemainingTime(-5f * completedActionCount);
+                }
+
+                previousActionCount = currentActionCount;
+                yield return null;
+            }
+        }
+        finally
+        {
+            context.OnGameContextEvent -= onContextEvent;
+        }
     }
 }

--- a/Assets/Event/EventsScripts/E40600.cs
+++ b/Assets/Event/EventsScripts/E40600.cs
@@ -41,12 +41,12 @@ public class E40600 : Event
         if(!CanChoiceOption1(performer)) return false;
         performer.ChangeHp(40f);
         InGameManager.Instance.EventManager.GuaranteeNextPrayerOrSpeech();
-        return true;
+        return FinishChoice(1, true);
     }
 
     public override bool OnChoiceOption2(Cardinal performer)
     {
         if(!CanChoiceOption2(performer)) return false;
-        return true;
+        return FinishChoice(2, true);
     }
 }

--- a/Assets/Event/EventsScripts/E40600.cs
+++ b/Assets/Event/EventsScripts/E40600.cs
@@ -40,7 +40,7 @@ public class E40600 : Event
     {
         if(!CanChoiceOption1(performer)) return false;
         performer.ChangeHp(40f);
-        // 다음 기도/연설 시 무조건 성공 처리 필요
+        InGameManager.Instance.EventManager.GuaranteeNextPrayerOrSpeech();
         return true;
     }
 

--- a/Assets/Event/EventsScripts/E50100.cs
+++ b/Assets/Event/EventsScripts/E50100.cs
@@ -3,6 +3,8 @@ using UnityEngine;
 [CreateAssetMenu(fileName = "E50100", menuName = "Events/커피 회동")]
 public class E50100 : Event
 {
+    [SerializeField] private float columnProximityDistance = 1.5f;
+
     void Reset()
     {
         eventID = "E50100";
@@ -22,7 +24,6 @@ public class E50100 : Event
         option1FailResult = "체력 - 25";
         option2 = "";
 
-        // 성공 확률: 기본 50%, 기둥과 가까운 거리 안에 있다면 80% 처리 필요
     }
 
     public override bool CanChoiceOption1(Cardinal performer)
@@ -39,7 +40,8 @@ public class E50100 : Event
     {
         if(!CanChoiceOption1(performer)) return false;
 
-        if(Random.value <= option1Chance)
+        float successChance = IsNearColumn(performer) ? 0.8f : option1Chance;
+        if(Random.value <= successChance)
         {
             StateController stateController = performer.GetComponent<StateController>();
             if(stateController != null) stateController.ApplyStun(5f);
@@ -53,5 +55,23 @@ public class E50100 : Event
     public override bool OnChoiceOption2(Cardinal performer)
     {
         return true;
+    }
+
+    private bool IsNearColumn(Cardinal performer)
+    {
+        if (performer == null) return false;
+
+        float maxSqrDistance = columnProximityDistance * columnProximityDistance;
+        SpriteRenderer[] renderers = FindObjectsByType<SpriteRenderer>(
+            FindObjectsInactive.Exclude,
+            FindObjectsSortMode.None);
+
+        foreach (SpriteRenderer renderer in renderers)
+        {
+            if (!renderer.gameObject.name.StartsWith("columns_", System.StringComparison.OrdinalIgnoreCase)) continue;
+            if (renderer.bounds.SqrDistance(performer.transform.position) <= maxSqrDistance) return true;
+        }
+
+        return false;
     }
 }

--- a/Assets/Event/EventsScripts/E50200.cs
+++ b/Assets/Event/EventsScripts/E50200.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using UnityEngine;
 
 [CreateAssetMenu(fileName = "E50200", menuName = "Events/목 좀 축이세요")]
@@ -40,7 +41,7 @@ public class E50200 : Event
         if(InGameManager.Instance.Context.RemainingTime <= 40f)
         {
             performer.ChangeHp(-20f);
-            performer.ChangeSpeed(1f);
+            performer.StartCoroutine(Co_ApplySpeedUntilConclaveEnd(performer, 1f));
             return true;
         }
 
@@ -52,5 +53,24 @@ public class E50200 : Event
     public override bool OnChoiceOption2(Cardinal performer)
     {
         return true;
+    }
+
+    private IEnumerator Co_ApplySpeedUntilConclaveEnd(Cardinal target, float delta)
+    {
+        if(target == null || InGameManager.Instance == null || InGameManager.Instance.Context == null) yield break;
+
+        bool isEnded = false;
+        GameContext context = InGameManager.Instance.Context;
+
+        void OnContextEvent(GameContext.GameContextEvent eventType)
+        {
+            if(eventType == GameContext.GameContextEvent.ConclaveEnd) isEnded = true;
+        }
+
+        target.ChangeSpeed(delta);
+        context.OnGameContextEvent += OnContextEvent;
+        yield return new WaitUntil(() => isEnded || target == null);
+        if(target != null) target.ChangeSpeed(-delta);
+        context.OnGameContextEvent -= OnContextEvent;
     }
 }

--- a/Assets/Event/EventsScripts/E50600.cs
+++ b/Assets/Event/EventsScripts/E50600.cs
@@ -1,9 +1,11 @@
-using System.Collections;
+using System.Collections.Generic;
 using UnityEngine;
 
 [CreateAssetMenu(fileName = "E50600", menuName = "Events/결코 다시 전쟁!")]
 public class E50600 : Event
 {
+    private const string MinHpEffectSource = "E50600";
+
     void Reset()
     {
         eventID = "E50600";
@@ -40,44 +42,42 @@ public class E50600 : Event
     {
         if(!CanChoiceOption1(performer)) return false;
 
-        foreach(var cardinal in CardinalManager.Instance.Cardinals)
+        foreach(Cardinal cardinal in GetRepresentativeCardinals(performer))
         {
             cardinal.ChangeInfluence(40f);
-            performer.StartCoroutine(Co_ApplyMinHpOneUntilConclaveEnd(cardinal));
+            cardinal.SetMinHpOneEffect(MinHpEffectSource, true);
         }
 
-        return true;
+        return FinishChoice(1, true);
     }
 
     public override bool OnChoiceOption2(Cardinal performer)
     {
         if(!CanChoiceOption2(performer)) return false;
 
-        foreach(var cardinal in CardinalManager.Instance.Cardinals)
+        foreach(Cardinal cardinal in GetRepresentativeCardinals(performer))
         {
-            performer.StartCoroutine(Co_ApplyMinHpOneUntilConclaveEnd(cardinal));
+            cardinal.SetMinHpOneEffect(MinHpEffectSource, true);
         }
 
         InGameManager.Instance.EventManager.SetFreePlotPietyForCurrentConclave();
-        return true;
+        return FinishChoice(2, true);
     }
 
-    private IEnumerator Co_ApplyMinHpOneUntilConclaveEnd(Cardinal target)
+    private IEnumerable<Cardinal> GetRepresentativeCardinals(Cardinal performer)
     {
-        if(target == null || InGameManager.Instance == null || InGameManager.Instance.Context == null) yield break;
-
-        bool isEnded = false;
-        GameContext context = InGameManager.Instance.Context;
-
-        void OnContextEvent(GameContext.GameContextEvent eventType)
+        HashSet<Cardinal> representatives = new HashSet<Cardinal>();
+        if (performer != null)
         {
-            if(eventType == GameContext.GameContextEvent.ConclaveEnd) isEnded = true;
+            representatives.Add(performer);
         }
 
-        target.SetMinHpOneEffect(true);
-        context.OnGameContextEvent += OnContextEvent;
-        yield return new WaitUntil(() => isEnded || target == null);
-        if(target != null) target.SetMinHpOneEffect(false);
-        context.OnGameContextEvent -= OnContextEvent;
+        for (int candidateNumber = 1; candidateNumber <= 3; candidateNumber++)
+        {
+            Cardinal candidate = GetCandidate(candidateNumber);
+            if (candidate != null) representatives.Add(candidate);
+        }
+
+        return representatives;
     }
 }

--- a/Assets/Event/EventsScripts/E50600.cs
+++ b/Assets/Event/EventsScripts/E50600.cs
@@ -58,7 +58,7 @@ public class E50600 : Event
             performer.StartCoroutine(Co_ApplyMinHpOneUntilConclaveEnd(cardinal));
         }
 
-        // 이번 썬ㅡ클라베 동안 공작 경건함 소모량 0 고정 처리 필요
+        InGameManager.Instance.EventManager.SetFreePlotPietyForCurrentConclave();
         return true;
     }
 

--- a/Assets/Event/SO/E31100.asset
+++ b/Assets/Event/SO/E31100.asset
@@ -24,7 +24,7 @@ MonoBehaviour:
     \uC788\uB2E4!\n\uAD50\uB2E8\uC758 \uC6B4\uBA85\uC774 \uB2F9\uC2E0\uC758 \uC190\uC5D0
     \uB2EC\uB838\uB2E4! \uB2F9\uC2E0\uC774 \uC6D0\uD558\uB294 \uAC83\uC740 \uBB34\uC5C7\uC77C\uAE4C?\""
   itemImage: {fileID: 0}
-  maxAppear: 1
+  maxAppear: 4
   eventWeightBase: 20
   eventWeightMultiplier: 0
   preEvents: []

--- a/Assets/Event/Scripts/Event.cs
+++ b/Assets/Event/Scripts/Event.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 
 public abstract class Event : ScriptableObject
 {
@@ -48,4 +49,94 @@ public abstract class Event : ScriptableObject
 
     public abstract bool OnChoiceOption1(Cardinal performer);
     public abstract bool OnChoiceOption2(Cardinal performer);
+
+    protected bool FinishChoice(int optionIndex, bool succeeded)
+    {
+        if (InGameManager.Instance != null && InGameManager.Instance.EventManager != null)
+        {
+            InGameManager.Instance.EventManager.RecordChoice(eventID, optionIndex, succeeded);
+        }
+
+        return succeeded;
+    }
+
+    protected bool FinishChoiceWithEnding(int optionIndex, EndingType endingType)
+    {
+        FinishChoice(optionIndex, true);
+        EndingContext.CaptureFromCurrentGame();
+        EndingContext.SetEventTrigger(eventID, optionIndex);
+        EndingResult.Set(endingType);
+        Time.timeScale = 1f;
+        SceneManager.LoadScene("EndingScene");
+        return true;
+    }
+
+    protected Cardinal GetCandidate(int candidateNumber)
+    {
+        if (candidateNumber < 1 || candidateNumber > 3 || CardinalManager.Instance == null)
+        {
+            return null;
+        }
+
+        StatsUI statsUI = CardinalManager.Instance.StatsUI;
+        Cardinal[] linked = statsUI != null ? statsUI.LinkedCardinals : null;
+        if (linked != null && linked.Length > candidateNumber && linked[candidateNumber] != null)
+        {
+            return linked[candidateNumber];
+        }
+
+        List<Cardinal> aiCardinals = CardinalManager.Instance.GetAICardinlas();
+        int index = candidateNumber - 1;
+        return index < aiCardinals.Count ? aiCardinals[index] : null;
+    }
+
+    protected void EliminateCandidate(int candidateNumber)
+    {
+        Cardinal candidate = GetCandidate(candidateNumber);
+        if (candidate != null)
+        {
+            candidate.ChangeHp(-candidate.Hp);
+        }
+    }
+
+    protected void SetCandidateStats(int candidateNumber, float hp, float influence, float piety)
+    {
+        Cardinal candidate = GetCandidate(candidateNumber);
+        if (candidate == null)
+        {
+            return;
+        }
+
+        candidate.ChangeHp(hp - candidate.Hp);
+        candidate.ChangeInfluence(influence - candidate.Influence);
+        candidate.ChangePiety(piety - candidate.Piety);
+    }
+
+    protected void CopyDefinitionFrom(Event source)
+    {
+        if (source == null || source == this) return;
+
+        eventID = source.eventID;
+        eventName = source.eventName;
+        eventDescription = source.eventDescription;
+        itemImage = source.itemImage;
+        maxAppear = source.maxAppear;
+        eventWeightBase = source.eventWeightBase;
+        eventWeightMultiplier = source.eventWeightMultiplier;
+        preEvents = source.preEvents;
+        conflictEvents = source.conflictEvents;
+        option1 = source.option1;
+        option1Chance = source.option1Chance;
+        option1Requirement = source.option1Requirement;
+        option1SuccessDescription = source.option1SuccessDescription;
+        option1SuccessResult = source.option1SuccessResult;
+        option1FailDescription = source.option1FailDescription;
+        option1FailResult = source.option1FailResult;
+        option2 = source.option2;
+        option2Chance = source.option2Chance;
+        option2SuccessDescription = source.option2SuccessDescription;
+        option2SuccessResult = source.option2SuccessResult;
+        option2FailDescription = source.option2FailDescription;
+        option2FailResult = source.option2FailResult;
+    }
 }

--- a/Assets/Event/Scripts/EventManager.cs
+++ b/Assets/Event/Scripts/EventManager.cs
@@ -226,8 +226,9 @@ public class EventManager : MonoBehaviour
         guaranteeNextPrayerOrSpeech = true;
     }
 
-    public bool TryConsumeGuaranteedPrayerOrSpeech()
+    public bool TryConsumeGuaranteedPrayerOrSpeech(Cardinal performer)
     {
+        if (performer == null || !performer.CompareTag("Player")) return false;
         if (!guaranteeNextPrayerOrSpeech) return false;
         guaranteeNextPrayerOrSpeech = false;
         return true;
@@ -258,6 +259,28 @@ public class EventManager : MonoBehaviour
             });
         }
 
+        foreach (var pair in choiceRecords.OrderBy(pair => pair.Key))
+        {
+            saveData.choices.Add(new EventChoiceSaveData
+            {
+                eventId = pair.Key,
+                optionIndex = pair.Value.optionIndex,
+                succeeded = pair.Value.succeeded
+            });
+        }
+
+        foreach (var pair in plotDamageBonuses.OrderBy(pair => pair.Key))
+        {
+            saveData.plotDamageBonuses.Add(new EventPlotDamageBonusSaveData
+            {
+                candidateNumber = pair.Key,
+                bonus = pair.Value
+            });
+        }
+
+        saveData.guaranteeNextPrayerOrSpeech = guaranteeNextPrayerOrSpeech;
+        saveData.freePlotPietyForCurrentConclave = freePlotPietyForCurrentConclave;
+
         return saveData;
     }
 
@@ -265,29 +288,83 @@ public class EventManager : MonoBehaviour
     {
         appeared.Clear();
         appearedCnt.Clear();
+        choiceRecords.Clear();
+        plotDamageBonuses.Clear();
+        ClearConclaveEffects();
 
-        if (saveData == null || saveData.records == null)
+        if (saveData == null)
         {
             return;
         }
 
-        foreach (var record in saveData.records)
+        if (saveData.records != null)
         {
-            if (record == null || string.IsNullOrWhiteSpace(record.eventId))
+            foreach (var record in saveData.records)
             {
-                continue;
-            }
+                if (record == null || string.IsNullOrWhiteSpace(record.eventId))
+                {
+                    continue;
+                }
 
-            Event restoredEvent = GetEventById(record.eventId);
-            if (restoredEvent == null)
-            {
-                Debug.LogWarning($"[Save] 이벤트 '{record.eventId}'를 찾지 못해 복원을 건너뜁니다.");
-                continue;
-            }
+                Event restoredEvent = GetEventById(record.eventId);
+                if (restoredEvent == null)
+                {
+                    Debug.LogWarning($"[Save] 이벤트 '{record.eventId}'를 찾지 못해 복원을 건너뜁니다.");
+                    continue;
+                }
 
-            appeared.Add(restoredEvent);
-            appearedCnt[restoredEvent] = Mathf.Max(0, record.appearCount);
+                appeared.Add(restoredEvent);
+                appearedCnt[restoredEvent] = Mathf.Max(0, record.appearCount);
+            }
         }
+
+        if (saveData.choices != null)
+        {
+            foreach (var choice in saveData.choices)
+            {
+                if (choice == null || string.IsNullOrWhiteSpace(choice.eventId) ||
+                    choice.optionIndex < 1 || choice.optionIndex > 2)
+                {
+                    continue;
+                }
+
+                Event restoredEvent = GetEventById(choice.eventId);
+                if (restoredEvent == null)
+                {
+                    Debug.LogWarning($"[Save] 선택 결과 이벤트 '{choice.eventId}'를 찾지 못해 복원을 건너뜁니다.");
+                    continue;
+                }
+
+                choiceRecords[choice.eventId] = new ChoiceRecord
+                {
+                    optionIndex = choice.optionIndex,
+                    succeeded = choice.succeeded
+                };
+
+                appeared.Add(restoredEvent);
+                if (!appearedCnt.ContainsKey(restoredEvent))
+                {
+                    appearedCnt[restoredEvent] = 1;
+                }
+            }
+        }
+
+        if (saveData.plotDamageBonuses != null)
+        {
+            foreach (var plotBonus in saveData.plotDamageBonuses)
+            {
+                if (plotBonus == null || plotBonus.candidateNumber < 1 || plotBonus.candidateNumber > 3 ||
+                    float.IsNaN(plotBonus.bonus) || float.IsInfinity(plotBonus.bonus))
+                {
+                    continue;
+                }
+
+                plotDamageBonuses[plotBonus.candidateNumber] = Mathf.Max(0f, plotBonus.bonus);
+            }
+        }
+
+        guaranteeNextPrayerOrSpeech = saveData.guaranteeNextPrayerOrSpeech;
+        freePlotPietyForCurrentConclave = saveData.freePlotPietyForCurrentConclave;
     }
 
     private Event PickWeightedEvent(List<Event> candidates)

--- a/Assets/Event/Scripts/EventManager.cs
+++ b/Assets/Event/Scripts/EventManager.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 
 public class EventManager : MonoBehaviour
@@ -7,58 +8,94 @@ public class EventManager : MonoBehaviour
 
     private readonly HashSet<Event> appeared = new();
     private readonly Dictionary<Event, int> appearedCnt = new();
+    private readonly Dictionary<string, ChoiceRecord> choiceRecords = new();
+    private readonly Dictionary<int, float> plotDamageBonuses = new();
+
+    private bool guaranteeNextPrayerOrSpeech;
+    private float prayerSpeechTimePenalty;
+    private bool freePlotPietyForCurrentConclave;
+
+    private static readonly Dictionary<string, string> RequiredPreEventIds = new()
+    {
+        { "E11200", "E11100" },
+        { "E11300", "E11200" },
+        { "E21000", "E20000" },
+        { "E21100", "E21000" },
+        { "E21101", "E21100" },
+        { "E31000", "E30000" },
+        { "E31100", "E31000" },
+        { "E31101", "E31100" },
+        { "E31200", "E31000" },
+        { "E31210", "E31200" },
+        { "E31211", "E31210" },
+        { "E31213", "E31212" },
+        { "E32000", "E31213" },
+        { "E32001", "E32000" },
+        { "E32002", "E32000" }
+    };
+
+    private static readonly Dictionary<string, HashSet<string>> ConflictEventIds = new()
+    {
+        { "E21100", NewIdSet("E31100", "E31101", "E31200", "E31210", "E32000", "E32001") },
+        { "E21101", NewIdSet("E31100", "E31101", "E31200", "E31210", "E32000", "E32001") },
+        { "E31100", NewIdSet("E21000", "E21100", "E31200", "E31210", "E32000", "E32001") },
+        { "E31101", NewIdSet("E21000", "E21100", "E31200", "E31210", "E32000", "E32001") },
+        { "E31200", NewIdSet("E21000", "E21100", "E31100", "E31101", "E32000", "E32001") },
+        { "E31210", NewIdSet("E21000", "E21100", "E31100", "E31101", "E32000", "E32001") },
+        { "E31211", NewIdSet("E21000", "E21100", "E31100", "E31101", "E31200", "E32000", "E32001") },
+        { "E31212", NewIdSet("E31213", "E32000", "E32001") },
+        { "E32001", NewIdSet("E32002") },
+        { "E32002", NewIdSet("E32001") }
+    };
+
+    private struct ChoiceRecord
+    {
+        public int optionIndex;
+        public bool succeeded;
+    }
 
     void Start()
     {
+        if (InGameManager.Instance != null && InGameManager.Instance.Context != null)
+        {
+            InGameManager.Instance.Context.OnGameContextEvent += HandleGameContextEvent;
+        }
+    }
 
+    void OnDestroy()
+    {
+        if (InGameManager.Instance != null && InGameManager.Instance.Context != null)
+        {
+            InGameManager.Instance.Context.OnGameContextEvent -= HandleGameContextEvent;
+        }
     }
 
     public Event PickAnyEvent()
     {
-        Event pickedEvent = null;
-        
-        float totalWeight = 0f;
-        foreach(var e in allEvents) totalWeight += e.GetEventWeight();
-        
-        float roll = Random.value * totalWeight;
-
-        float accWeight = 0f;
-        foreach(var e in allEvents)
-        {
-            accWeight += e.GetEventWeight();
-
-            if(roll <= accWeight)
-            {
-                pickedEvent = e;
-                break;
-            }
-
-            continue;
-        }
-
-        return pickedEvent;
+        return PickWeightedEvent(allEvents == null ? new List<Event>() : allEvents.Where(e => e != null).ToList());
     }
 
     public Event GetNewEvent()
     {
-        Event pickedEvent = null;
-
-        int tryCnt = 100;
-        while (tryCnt--  > 0)
+        if (allEvents == null)
         {
-            pickedEvent = PickAnyEvent();
-
-            if(pickedEvent == null) continue;
-
-            if(!HasRemaining(pickedEvent)) continue;
-            if(!PreEventSatisfied(pickedEvent)) continue;
-            if(!ConflictEventSatisfied(pickedEvent)) continue;
-
-            MarkEventAppeared(pickedEvent);
-            Debug.Log($"이벤트 \"{pickedEvent}\" 선택");
-            return pickedEvent;
+            return null;
         }
-        Debug.Log($"이벤트 선택 실패, currentEvent = \"{pickedEvent}\"");
+
+        List<Event> eligibleEvents = allEvents
+            .Where(e => e != null && HasRemaining(e) && PreEventSatisfied(e) &&
+                        ConflictEventSatisfied(e) && NarrativeConditionSatisfied(e))
+            .ToList();
+
+        Event pickedEvent = PickWeightedEvent(eligibleEvents);
+        if (pickedEvent == null)
+        {
+            Debug.LogWarning("[Event] 현재 조건을 만족하는 이벤트가 없습니다.");
+            return null;
+        }
+
+        MarkEventAppeared(pickedEvent);
+        Debug.Log($"이벤트 \"{pickedEvent.eventID}\" 선택");
         return pickedEvent;
     }
 
@@ -72,6 +109,11 @@ public class EventManager : MonoBehaviour
 
     public bool PreEventSatisfied(Event e)
     {
+        if (RequiredPreEventIds.TryGetValue(e.eventID, out string requiredId))
+        {
+            return HasAppeared(requiredId);
+        }
+
         var pres = e.preEvents;
 
         if(pres == null || pres.Count == 0) return true;
@@ -101,6 +143,15 @@ public class EventManager : MonoBehaviour
 
     public bool ConflictEventSatisfied(Event e)
     {
+        if (ConflictEventIds.TryGetValue(e.eventID, out HashSet<string> conflictIds))
+        {
+            foreach (string conflictId in conflictIds)
+            {
+                if (HasAppeared(conflictId)) return false;
+            }
+            return true;
+        }
+
         var conflicts = e.conflictEvents;
 
         if(conflicts == null || conflicts.Count == 0) return true;
@@ -117,6 +168,8 @@ public class EventManager : MonoBehaviour
 
     public Event GetEventById(string eventId)
     {
+        if (allEvents == null) return null;
+
         foreach(var e in allEvents)
         {
             if(!e) continue;
@@ -131,7 +184,69 @@ public class EventManager : MonoBehaviour
     {
         appeared.Clear();
         appearedCnt.Clear();
+        choiceRecords.Clear();
+        plotDamageBonuses.Clear();
+        ClearConclaveEffects();
     }
+
+    public void RecordChoice(string eventId, int optionIndex, bool succeeded)
+    {
+        if (string.IsNullOrWhiteSpace(eventId)) return;
+        choiceRecords[eventId] = new ChoiceRecord { optionIndex = optionIndex, succeeded = succeeded };
+
+        Event chosenEvent = GetEventById(eventId);
+        if (chosenEvent != null && !appeared.Contains(chosenEvent))
+        {
+            appeared.Add(chosenEvent);
+            appearedCnt[chosenEvent] = Mathf.Max(1, appearedCnt.TryGetValue(chosenEvent, out int count) ? count : 0);
+        }
+    }
+
+    public bool WasChoice(string eventId, int optionIndex, bool? succeeded = null)
+    {
+        if (!choiceRecords.TryGetValue(eventId, out ChoiceRecord record) || record.optionIndex != optionIndex)
+        {
+            return false;
+        }
+
+        return !succeeded.HasValue || record.succeeded == succeeded.Value;
+    }
+
+    public void SetPlotDamageBonus(int candidateNumber, float bonus)
+    {
+        plotDamageBonuses[candidateNumber] = bonus;
+    }
+
+    public float GetPlotDamageBonus(int candidateNumber)
+    {
+        return plotDamageBonuses.TryGetValue(candidateNumber, out float bonus) ? bonus : 0f;
+    }
+
+    public void GuaranteeNextPrayerOrSpeech()
+    {
+        guaranteeNextPrayerOrSpeech = true;
+    }
+
+    public bool TryConsumeGuaranteedPrayerOrSpeech()
+    {
+        if (!guaranteeNextPrayerOrSpeech) return false;
+        guaranteeNextPrayerOrSpeech = false;
+        return true;
+    }
+
+    public void SetPrayerSpeechTimePenalty(float seconds)
+    {
+        prayerSpeechTimePenalty = Mathf.Max(0f, seconds);
+    }
+
+    public float PrayerSpeechTimePenalty => prayerSpeechTimePenalty;
+
+    public void SetFreePlotPietyForCurrentConclave()
+    {
+        freePlotPietyForCurrentConclave = true;
+    }
+
+    public bool FreePlotPietyForCurrentConclave => freePlotPietyForCurrentConclave;
 
     public EventManagerSaveData CaptureSaveData()
     {
@@ -181,5 +296,111 @@ public class EventManager : MonoBehaviour
             appeared.Add(restoredEvent);
             appearedCnt[restoredEvent] = Mathf.Max(0, record.appearCount);
         }
+    }
+
+    private Event PickWeightedEvent(List<Event> candidates)
+    {
+        if (candidates == null || candidates.Count == 0) return null;
+
+        List<Event> forced = candidates.Where(e => float.IsPositiveInfinity(GetSelectionWeight(e))).ToList();
+        if (forced.Count > 0)
+        {
+            return forced[Random.Range(0, forced.Count)];
+        }
+
+        float totalWeight = 0f;
+        foreach (Event candidate in candidates)
+        {
+            totalWeight += Mathf.Max(0f, GetSelectionWeight(candidate));
+        }
+
+        if (totalWeight <= 0f) return null;
+
+        float roll = Random.value * totalWeight;
+        float accumulated = 0f;
+        foreach (Event candidate in candidates)
+        {
+            accumulated += Mathf.Max(0f, GetSelectionWeight(candidate));
+            if (roll <= accumulated) return candidate;
+        }
+
+        return candidates[candidates.Count - 1];
+    }
+
+    private float GetSelectionWeight(Event e)
+    {
+        switch (e.eventID)
+        {
+            case "E11200":
+            case "E11300":
+            case "E21101":
+                return float.PositiveInfinity;
+            default:
+                return e.GetEventWeight();
+        }
+    }
+
+    private bool NarrativeConditionSatisfied(Event e)
+    {
+        switch (e.eventID)
+        {
+            case "E21100": return WasChoice("E21000", 1, true);
+            case "E31100": return IsCandidateEliminated(3);
+            case "E31101": return WasChoice("E31100", 1, true);
+            case "E31200": return IsCandidateEliminated(2) && !IsCandidateEliminated(1);
+            // 기획 행의 선행(E31200)과 서술을 함께 만족시키는 분기다.
+            case "E31210": return WasChoice("E31200", 1, true);
+            case "E31211": return !IsCandidateEliminated(1) && WasChoice("E31210", 2, false);
+            case "E32000": return WasChoice("E31213", 2, true);
+            case "E32001": return WasChoice("E32000", 1, false);
+            case "E32002": return !WasChoice("E32000", 1, false);
+            default: return true;
+        }
+    }
+
+    private bool HasAppeared(string eventId)
+    {
+        Event evt = GetEventById(eventId);
+        return evt != null && appeared.Contains(evt);
+    }
+
+    private bool IsCandidateEliminated(int candidateNumber)
+    {
+        if (CardinalManager.Instance == null) return false;
+
+        StatsUI statsUI = CardinalManager.Instance.StatsUI;
+        Cardinal[] linked = statsUI != null ? statsUI.LinkedCardinals : null;
+        Cardinal candidate = linked != null && linked.Length > candidateNumber
+            ? linked[candidateNumber]
+            : null;
+
+        if (candidate == null)
+        {
+            List<Cardinal> ai = CardinalManager.Instance.GetAICardinlas();
+            int index = candidateNumber - 1;
+            candidate = index < ai.Count ? ai[index] : null;
+        }
+
+        return candidate != null && (candidate.Hp <= 0f || candidate.IsKnockedOut);
+    }
+
+    private void HandleGameContextEvent(GameContext.GameContextEvent eventType)
+    {
+        if (eventType == GameContext.GameContextEvent.ConclaveEnd)
+        {
+            ClearConclaveEffects();
+        }
+    }
+
+    private void ClearConclaveEffects()
+    {
+        guaranteeNextPrayerOrSpeech = false;
+        prayerSpeechTimePenalty = 0f;
+        freePlotPietyForCurrentConclave = false;
+    }
+
+    private static HashSet<string> NewIdSet(params string[] ids)
+    {
+        return new HashSet<string>(ids);
     }
 }

--- a/Assets/Event/Scripts/EventManager.cs
+++ b/Assets/Event/Scripts/EventManager.cs
@@ -12,7 +12,6 @@ public class EventManager : MonoBehaviour
     private readonly Dictionary<int, float> plotDamageBonuses = new();
 
     private bool guaranteeNextPrayerOrSpeech;
-    private float prayerSpeechTimePenalty;
     private bool freePlotPietyForCurrentConclave;
 
     private static readonly Dictionary<string, string> RequiredPreEventIds = new()
@@ -234,13 +233,6 @@ public class EventManager : MonoBehaviour
         return true;
     }
 
-    public void SetPrayerSpeechTimePenalty(float seconds)
-    {
-        prayerSpeechTimePenalty = Mathf.Max(0f, seconds);
-    }
-
-    public float PrayerSpeechTimePenalty => prayerSpeechTimePenalty;
-
     public void SetFreePlotPietyForCurrentConclave()
     {
         freePlotPietyForCurrentConclave = true;
@@ -395,7 +387,6 @@ public class EventManager : MonoBehaviour
     private void ClearConclaveEffects()
     {
         guaranteeNextPrayerOrSpeech = false;
-        prayerSpeechTimePenalty = 0f;
         freePlotPietyForCurrentConclave = false;
     }
 

--- a/Assets/Event/Scripts/EventManager.cs
+++ b/Assets/Event/Scripts/EventManager.cs
@@ -221,6 +221,17 @@ public class EventManager : MonoBehaviour
         return plotDamageBonuses.TryGetValue(candidateNumber, out float bonus) ? bonus : 0f;
     }
 
+    public float ModifyPlotHpDelta(Cardinal performer, Cardinal target, float delta)
+    {
+        if (delta >= 0f || performer == null || target == null || !performer.CompareTag("Player"))
+        {
+            return delta;
+        }
+
+        int candidateNumber = GetCandidateNumber(target);
+        return candidateNumber > 0 ? delta - GetPlotDamageBonus(candidateNumber) : delta;
+    }
+
     public void GuaranteeNextPrayerOrSpeech()
     {
         guaranteeNextPrayerOrSpeech = true;
@@ -240,6 +251,11 @@ public class EventManager : MonoBehaviour
     }
 
     public bool FreePlotPietyForCurrentConclave => freePlotPietyForCurrentConclave;
+
+    public bool IsPlotPietyCostWaived(Cardinal performer)
+    {
+        return freePlotPietyForCurrentConclave && performer != null && performer.CompareTag("Player");
+    }
 
     public EventManagerSaveData CaptureSaveData()
     {
@@ -453,6 +469,29 @@ public class EventManager : MonoBehaviour
         return candidate != null && (candidate.Hp <= 0f || candidate.IsKnockedOut);
     }
 
+    private int GetCandidateNumber(Cardinal target)
+    {
+        if (target == null || CardinalManager.Instance == null) return 0;
+
+        StatsUI statsUI = CardinalManager.Instance.StatsUI;
+        Cardinal[] linked = statsUI != null ? statsUI.LinkedCardinals : null;
+        if (linked != null)
+        {
+            for (int candidateNumber = 1; candidateNumber <= 3 && candidateNumber < linked.Length; candidateNumber++)
+            {
+                if (linked[candidateNumber] == target) return candidateNumber;
+            }
+        }
+
+        List<Cardinal> ai = CardinalManager.Instance.GetAICardinlas();
+        for (int index = 0; index < 3 && index < ai.Count; index++)
+        {
+            if (ai[index] == target) return index + 1;
+        }
+
+        return 0;
+    }
+
     private void HandleGameContextEvent(GameContext.GameContextEvent eventType)
     {
         if (eventType == GameContext.GameContextEvent.ConclaveEnd)
@@ -463,6 +502,7 @@ public class EventManager : MonoBehaviour
 
     private void ClearConclaveEffects()
     {
+        plotDamageBonuses.Clear();
         guaranteeNextPrayerOrSpeech = false;
         freePlotPietyForCurrentConclave = false;
     }

--- a/Assets/Plot/Scripts/Plot List/P001.cs
+++ b/Assets/Plot/Scripts/Plot List/P001.cs
@@ -48,7 +48,7 @@ public class P001 : Plot
     {
         if(!CanExecute(performer)) return;
 
-        performer.ChangePiety(-pietyCost);
+        PayCost(performer);
         
         performer.ChangeHp(hpDelta);
     }

--- a/Assets/Plot/Scripts/Plot List/P002.cs
+++ b/Assets/Plot/Scripts/Plot List/P002.cs
@@ -48,7 +48,7 @@ public class P002 : Plot
     {
         if(!CanExecute(performer)) return;
 
-        performer.ChangePiety(-pietyCost);
+        PayCost(performer);
 
         performer.ChangeInfluence(influenceDelta);
     }

--- a/Assets/Plot/Scripts/Plot List/P003.cs
+++ b/Assets/Plot/Scripts/Plot List/P003.cs
@@ -48,7 +48,7 @@ public class P003 : Plot
     {
         if(!CanExecute(performer)) return;
 
-        performer.ChangePiety(-pietyCost);
+        PayCost(performer);
 
         var cm = CardinalManager.Instance;
 

--- a/Assets/Plot/Scripts/Plot List/P004.cs
+++ b/Assets/Plot/Scripts/Plot List/P004.cs
@@ -49,7 +49,7 @@ public class P004 : Plot
     {
         if(!CanExecute(performer)) return;
 
-        performer.ChangePiety(-pietyCost);
+        PayCost(performer);
 
         performer.ChangeInfluence(influenceDelta);
     }

--- a/Assets/Plot/Scripts/Plot List/P005.cs
+++ b/Assets/Plot/Scripts/Plot List/P005.cs
@@ -48,13 +48,12 @@ public class P005 : Plot
     {
         if (!CanExecute(performer)) return;
 
-        performer.ChangePiety(-pietyCost);
+        PayCost(performer);
 
         var cm = CardinalManager.Instance;
 
         int targetIndex = Random.Range(0, 3);
 
-        cm.Cardinals[targetIndex].ChangeHp(hpDelta);
+        ApplyHpDelta(performer, cm.Cardinals[targetIndex], hpDelta);
     }
 }
-    

--- a/Assets/Plot/Scripts/Plot List/P006.cs
+++ b/Assets/Plot/Scripts/Plot List/P006.cs
@@ -48,7 +48,7 @@ public class P006 : Plot
     {
         if (!CanExecute(performer)) return;
 
-        performer.ChangePiety(-pietyCost);
+        PayCost(performer);
 
         var cm = CardinalManager.Instance;
 

--- a/Assets/Plot/Scripts/Plot List/P007.cs
+++ b/Assets/Plot/Scripts/Plot List/P007.cs
@@ -52,7 +52,7 @@ public class P007 : Plot
     {
         if (!CanExecute(performer)) return;
 
-        performer.ChangePiety(-pietyCost);
+        PayCost(performer);
 
         var cm = CardinalManager.Instance;
 

--- a/Assets/Plot/Scripts/Plot List/P008.cs
+++ b/Assets/Plot/Scripts/Plot List/P008.cs
@@ -58,7 +58,7 @@ public class P008 : Plot
     {
         if(!CanExecute(performer)) return;
 
-        performer.ChangePiety(-pietyCost);
+        PayCost(performer);
 
         performer.ChangeHp(hpDelta);
         performer.ChangeInfluence(influenceDelta);

--- a/Assets/Plot/Scripts/Plot List/P009.cs
+++ b/Assets/Plot/Scripts/Plot List/P009.cs
@@ -48,7 +48,7 @@ public class P009 : Plot
     {
         if (!CanExecute(performer)) return;
 
-        performer.ChangePiety(-pietyCost);
+        PayCost(performer);
 
         var cm = CardinalManager.Instance;
 
@@ -69,7 +69,7 @@ public class P009 : Plot
             }
         }
 
-        cm.Cardinals[lowestPietyCardinal].ChangeHp(hpDelta);
+        ApplyHpDelta(performer, cm.Cardinals[lowestPietyCardinal], hpDelta);
     }
 
 }

--- a/Assets/Plot/Scripts/Plot List/P010.cs
+++ b/Assets/Plot/Scripts/Plot List/P010.cs
@@ -49,7 +49,7 @@ public class P010 : Plot
     {
         if (!CanExecute(performer)) return;
 
-        performer.ChangePiety(-pietyCost);
+        PayCost(performer);
 
         var cm = CardinalManager.Instance;
 
@@ -70,7 +70,7 @@ public class P010 : Plot
             }
         }
 
-        cm.Cardinals[lowestPietyCardinal].ChangeHp(hpDelta);
+        ApplyHpDelta(performer, cm.Cardinals[lowestPietyCardinal], hpDelta);
         cm.Cardinals[lowestPietyCardinal].ChangePiety(pietyDelta);
     }
 

--- a/Assets/Plot/Scripts/Plot List/P011.cs
+++ b/Assets/Plot/Scripts/Plot List/P011.cs
@@ -53,13 +53,13 @@ public class P011 : Plot
     {
         if (!CanExecute(performer)) return;
 
-        performer.ChangePiety(-pietyCost);
+        PayCost(performer);
 
         var cm = CardinalManager.Instance;
 
         if (Random.value < 0.5f)
         {
-            performer.ChangeHp(hpDecrease);
+            ApplyHpDelta(performer, performer, hpDecrease);
             performer.ChangeInfluence(influenceDelta);
         }
         else
@@ -71,7 +71,7 @@ public class P011 : Plot
         {
             if (Random.value < 0.5f)
             {
-                cm.Cardinals[i].ChangeHp(hpDecrease);
+                ApplyHpDelta(performer, cm.Cardinals[i], hpDecrease);
                 cm.Cardinals[i].ChangeInfluence(influenceDelta);
             }
             else

--- a/Assets/Plot/Scripts/Plot List/P012.cs
+++ b/Assets/Plot/Scripts/Plot List/P012.cs
@@ -47,7 +47,7 @@ public class P012 : Plot
     {
         if(!CanExecute(performer)) return;
 
-        performer.ChangePiety(-pietyCost);
+        PayCost(performer);
         
         performer.ChangeHp(hpDelta);
     }

--- a/Assets/Plot/Scripts/Plot List/P013.cs
+++ b/Assets/Plot/Scripts/Plot List/P013.cs
@@ -48,7 +48,7 @@ public class P013 : Plot
     {
         if(!CanExecute(performer)) return;
 
-        performer.ChangePiety(-pietyCost);
+        PayCost(performer);
 
         performer.ChangeInfluence(influenceDelta);
     }

--- a/Assets/Plot/Scripts/Plot List/P014.cs
+++ b/Assets/Plot/Scripts/Plot List/P014.cs
@@ -46,7 +46,7 @@ public class P014 : Plot
     {
         if(!CanExecute(performer)) return;
 
-        performer.ChangePiety(-pietyCost);
+        PayCost(performer);
 
         performer.ChangePiety(pietyDelta);
     }

--- a/Assets/Plot/Scripts/Plot List/P015.cs
+++ b/Assets/Plot/Scripts/Plot List/P015.cs
@@ -48,7 +48,7 @@ public class P015 : Plot
     {
         if (!CanExecute(performer)) return;
 
-        performer.ChangePiety(-pietyCost);
+        PayCost(performer);
 
         var cm = CardinalManager.Instance;
 

--- a/Assets/Plot/Scripts/Plot List/P016.cs
+++ b/Assets/Plot/Scripts/Plot List/P016.cs
@@ -58,7 +58,7 @@ public class P016 : Plot
     {
         if(!CanExecute(performer)) return;
 
-        performer.ChangePiety(-pietyCost);
+        PayCost(performer);
 
         performer.ChangeHp(hpDelta);
         performer.ChangeInfluence(influenceDelta);

--- a/Assets/Plot/Scripts/Plot List/P017.cs
+++ b/Assets/Plot/Scripts/Plot List/P017.cs
@@ -48,7 +48,7 @@ public class P017 : Plot
     {
         if (!CanExecute(performer)) return;
 
-        performer.ChangePiety(-pietyCost);
+        PayCost(performer);
 
         var cm = CardinalManager.Instance;
 
@@ -57,7 +57,7 @@ public class P017 : Plot
             .ThenBy(c => Random.value)
             .LastOrDefault();
 
-        target.ChangeHp(hpDelta);
+        ApplyHpDelta(performer, target, hpDelta);
     }
 
 }

--- a/Assets/Plot/Scripts/Plot List/P018.cs
+++ b/Assets/Plot/Scripts/Plot List/P018.cs
@@ -49,7 +49,7 @@ public class P018 : Plot
     {
         if (!CanExecute(performer)) return;
 
-        performer.ChangePiety(-pietyCost);
+        PayCost(performer);
 
         var cm = CardinalManager.Instance;
 
@@ -57,7 +57,7 @@ public class P018 : Plot
 
         for (int i = 0; i < 3; i++)
         {
-            cm.Cardinals[i].ChangeHp(hpDelta);
+            ApplyHpDelta(performer, cm.Cardinals[i], hpDelta);
         }
     }
 

--- a/Assets/Plot/Scripts/Plot List/P019.cs
+++ b/Assets/Plot/Scripts/Plot List/P019.cs
@@ -48,7 +48,7 @@ public class P019 : Plot
     {
         if (!CanExecute(performer)) return;
 
-        performer.ChangePiety(-pietyCost);
+        PayCost(performer);
 
         var cm = CardinalManager.Instance;
 

--- a/Assets/Plot/Scripts/Plot List/P020.cs
+++ b/Assets/Plot/Scripts/Plot List/P020.cs
@@ -47,7 +47,7 @@ public class P020 : Plot
     {
         if (!CanExecute(performer)) return;
 
-        performer.ChangePiety(-pietyCost);
+        PayCost(performer);
 
         for (int i = 0; i < rewardCount; i++)
         {
@@ -76,5 +76,3 @@ public class P020 : Plot
     }
 
 }
-
- 

--- a/Assets/Plot/Scripts/Plot List/P021.cs
+++ b/Assets/Plot/Scripts/Plot List/P021.cs
@@ -56,7 +56,7 @@ public class P021 : Plot
     {
         if (!CanExecute(performer)) return;
 
-        performer.ChangePiety(-pietyCost);
+        PayCost(performer);
 
         Debug.Log("P021 사용");
 

--- a/Assets/Plot/Scripts/Plot List/P022.cs
+++ b/Assets/Plot/Scripts/Plot List/P022.cs
@@ -12,6 +12,7 @@ public class P022 : Plot
     [SerializeField] private int duration;
 
     public override int cost => hpCost;
+    public override PlotCostResource CostResource => PlotCostResource.Hp;
 
     void Reset()
     {
@@ -50,7 +51,7 @@ public class P022 : Plot
     {
         if (!CanExecute(performer)) return;
 
-        performer.ChangeHp(-hpCost);
+        PayCost(performer);
 
         performer.StartCoroutine(SpeedBoostRoutine(performer));
     }

--- a/Assets/Plot/Scripts/Plot List/P023.cs
+++ b/Assets/Plot/Scripts/Plot List/P023.cs
@@ -50,7 +50,7 @@ public class P023 : Plot
     {
         if (!CanExecute(performer)) return;
 
-        performer.ChangePiety(-pietyCost);
+        PayCost(performer);
 
         var cm = CardinalManager.Instance;
 

--- a/Assets/Plot/Scripts/Plot List/P024.cs
+++ b/Assets/Plot/Scripts/Plot List/P024.cs
@@ -47,7 +47,7 @@ public class P024 : Plot
     {
         if (!CanExecute(performer)) return;
 
-        performer.ChangePiety(-pietyCost);
+        PayCost(performer);
 
         float hp = performer.Hp;
         float pol = performer.Influence;

--- a/Assets/Plot/Scripts/Plot List/P025.cs
+++ b/Assets/Plot/Scripts/Plot List/P025.cs
@@ -47,7 +47,7 @@ public class P025 : Plot
     {
         if (!CanExecute(performer)) return;
 
-        performer.ChangePiety(-pietyCost);
+        PayCost(performer);
 
         var em = ElectionManager.Instance;
 

--- a/Assets/Plot/Scripts/Plot List/P026.cs
+++ b/Assets/Plot/Scripts/Plot List/P026.cs
@@ -48,7 +48,7 @@ public class P026 : Plot
     {
         if (!CanExecute(performer)) return;
 
-        performer.ChangePiety(-pietyCost);
+        PayCost(performer);
 
         for (int i = 0; i < rewardCount; i++)
         {

--- a/Assets/Plot/Scripts/Plot List/P027.cs
+++ b/Assets/Plot/Scripts/Plot List/P027.cs
@@ -45,7 +45,7 @@ public class P027 : Plot
     {
         if (!CanExecute(performer)) return;
 
-        performer.ChangePiety(-pietyCost);
+        PayCost(performer);
 
         
     }

--- a/Assets/Plot/Scripts/Plot List/P028.cs
+++ b/Assets/Plot/Scripts/Plot List/P028.cs
@@ -46,7 +46,7 @@ public class P028 : Plot
     {
         if (!CanExecute(performer)) return;
 
-        performer.ChangePiety(-pietyCost);
+        PayCost(performer);
 
         var cm = CardinalManager.Instance;
 

--- a/Assets/Plot/Scripts/Plot List/P029.cs
+++ b/Assets/Plot/Scripts/Plot List/P029.cs
@@ -50,7 +50,7 @@ public class P029 : Plot
     {
         if (!CanExecute(performer)) return;
 
-        performer.ChangePiety(-pietyCost);
+        PayCost(performer);
 
         performer.ChangeHp(hpDelta);
         performer.ChangeInfluence(influenceDelta);

--- a/Assets/Plot/Scripts/Plot List/P030.cs
+++ b/Assets/Plot/Scripts/Plot List/P030.cs
@@ -7,6 +7,8 @@ using static UnityEngine.GraphicsBuffer;
 
 public class P030 : Plot
 {
+    private const string MinHpEffectSource = "P030";
+
     [Header("해당 공작 설정")]
     [SerializeField] private int minInfluence;
     [SerializeField] private int pietyCost;
@@ -51,7 +53,7 @@ public class P030 : Plot
     {
         if (!CanExecute(performer)) return;
 
-        performer.ChangePiety(-pietyCost);
+        PayCost(performer);
 
         var cm = CardinalManager.Instance;
 
@@ -83,7 +85,7 @@ public class P030 : Plot
             }
         }
 
-        performer.SetMinHpOneEffect(true);
+        performer.SetMinHpOneEffect(MinHpEffectSource, true);
         Debug.Log("최소 체력 1 ON");
         context.OnGameContextEvent += OnContextEvent;
 
@@ -91,7 +93,7 @@ public class P030 : Plot
 
         if (performer != null)
         {
-            performer.SetMinHpOneEffect(false);
+            performer.SetMinHpOneEffect(MinHpEffectSource, false);
             Debug.Log("최소 체력 1 OFF");
         }
 
@@ -101,4 +103,3 @@ public class P030 : Plot
         }
     }
 }
-

--- a/Assets/Plot/Scripts/Plot List/P031.cs
+++ b/Assets/Plot/Scripts/Plot List/P031.cs
@@ -48,7 +48,7 @@ public class P031 : Plot
     {
         if (!CanExecute(performer)) return;
 
-        performer.ChangePiety(-pietyCost);
+        PayCost(performer);
 
         float currentInfluence = performer.Influence;
 

--- a/Assets/Plot/Scripts/Plot List/P032.cs
+++ b/Assets/Plot/Scripts/Plot List/P032.cs
@@ -49,7 +49,7 @@ public class P032 : Plot
     {
         if (!CanExecute(performer)) return;
 
-        performer.ChangePiety(-pietyCost);
+        PayCost(performer);
 
         for (int i = 0; i < rewardCount; i++)
         {

--- a/Assets/Plot/Scripts/Plot List/P033.cs
+++ b/Assets/Plot/Scripts/Plot List/P033.cs
@@ -49,7 +49,7 @@ public class P033 : Plot
     {
         if (!CanExecute(performer)) return;
 
-        performer.ChangePiety(-pietyCost);
+        PayCost(performer);
 
         PlotManager.Instance.StartCoroutine(RevengeRoutine(performer));
     }
@@ -104,11 +104,11 @@ public class P033 : Plot
 
         if (totalDamageTaken > 0)
         {
-            ExecuteMassiveDamage(totalDamageTaken);
+            ExecuteMassiveDamage(performer, totalDamageTaken);
         }
     }
 
-    private void ExecuteMassiveDamage(float damage)
+    private void ExecuteMassiveDamage(Cardinal performer, float damage)
     {
         if (damage <= 0) return;
 
@@ -117,7 +117,7 @@ public class P033 : Plot
         for (int i = 0; i < 3; i++)
         {
             var target = cm.Cardinals[i];
-            target.ChangeHp(-damage);
+            ApplyHpDelta(performer, target, -damage);
         }
     }
 }

--- a/Assets/Plot/Scripts/Plot List/P034.cs
+++ b/Assets/Plot/Scripts/Plot List/P034.cs
@@ -50,7 +50,7 @@ public class P034 : Plot
     {
         if (!CanExecute(performer)) return;
 
-        performer.ChangePiety(-pietyCost);
+        PayCost(performer);
 
         var cm = CardinalManager.Instance;
 

--- a/Assets/Plot/Scripts/Plot.cs
+++ b/Assets/Plot/Scripts/Plot.cs
@@ -1,6 +1,7 @@
 ﻿using UnityEngine;
 
 public enum PlotGrade { Common, Rare, Legendary }
+public enum PlotCostResource { Piety, Hp }
 
 public abstract class Plot : ScriptableObject
 {
@@ -16,6 +17,7 @@ public abstract class Plot : ScriptableObject
     [SerializeField] public float plotWeightMultiplier;
 
     public virtual int cost => 0;
+    public virtual PlotCostResource CostResource => PlotCostResource.Piety;
 
     public float GetPlotWeight()
     {
@@ -29,6 +31,44 @@ public abstract class Plot : ScriptableObject
 
     // 비용 확인 함수, 구현은 자식 클래스에서 직접
     public abstract bool IsCostEnough(Cardinal performer);
+
+    public bool IsEffectiveCostEnough(Cardinal performer)
+    {
+        if (CostResource == PlotCostResource.Piety && IsPietyCostWaived(performer)) return true;
+        return IsCostEnough(performer);
+    }
+
+    protected void PayCost(Cardinal performer)
+    {
+        if (performer == null || cost <= 0) return;
+
+        if (CostResource == PlotCostResource.Piety)
+        {
+            if (!IsPietyCostWaived(performer)) performer.ChangePiety(-cost);
+            return;
+        }
+
+        performer.ChangeHp(-cost);
+    }
+
+    protected void ApplyHpDelta(Cardinal performer, Cardinal target, float delta)
+    {
+        if (target == null) return;
+
+        EventManager eventManager = InGameManager.Instance != null
+            ? InGameManager.Instance.EventManager
+            : null;
+        float effectiveDelta = eventManager != null
+            ? eventManager.ModifyPlotHpDelta(performer, target, delta)
+            : delta;
+        target.ChangeHp(effectiveDelta);
+    }
+
+    private static bool IsPietyCostWaived(Cardinal performer)
+    {
+        return InGameManager.Instance != null && InGameManager.Instance.EventManager != null &&
+            InGameManager.Instance.EventManager.IsPlotPietyCostWaived(performer);
+    }
 
     // 실제 실행시 로직 함수, 구현은 자식 클래스에서 직접
     public abstract void Execute(Cardinal performer);

--- a/Assets/UI/Scripts/InGame/PlotUI.cs
+++ b/Assets/UI/Scripts/InGame/PlotUI.cs
@@ -179,7 +179,7 @@ public class PlotUI : MonoBehaviour
         var buttonText = plotUseButtons[index].GetComponentInChildren<TextMeshProUGUI>();
 
         // 조건 확인
-        bool isPietyEnough = currentPlot.IsCostEnough(performer);
+        bool isPietyEnough = currentPlot.IsEffectiveCostEnough(performer);
         bool canExecute = currentPlot.CanExecute(performer);
 
         // 버튼 활성화 설정

--- a/Assets/UI/Scripts/InGame/StatsUI/EventUI/EventResult.cs
+++ b/Assets/UI/Scripts/InGame/StatsUI/EventUI/EventResult.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using UnityEngine;
 using UnityEngine.UI;
 using TMPro;
@@ -17,10 +18,12 @@ class EventResult : MonoBehaviour
         ButtonText.text = "확인";
         currentEvent = evt;
         title.text = evt.eventName;
+        bool succeeded;
 
         if(result == 1)
         {
-            if(evt.OnChoiceOption1(UIManager.Instance.Ingame.Stats.LinkedCardinals[0]) == true)
+            succeeded = evt.OnChoiceOption1(UIManager.Instance.Ingame.Stats.LinkedCardinals[0]);
+            if(succeeded)
             {
                 text.text = evt.option1SuccessDescription;
                 this.result.text = evt.option1SuccessResult;
@@ -33,7 +36,8 @@ class EventResult : MonoBehaviour
         }
         else if(result == 2)
         {
-            if(evt.OnChoiceOption2(UIManager.Instance.Ingame.Stats.LinkedCardinals[0]) == true)
+            succeeded = evt.OnChoiceOption2(UIManager.Instance.Ingame.Stats.LinkedCardinals[0]);
+            if(succeeded)
             {
                 text.text = evt.option2SuccessDescription;
                 this.result.text = evt.option2SuccessResult;
@@ -43,6 +47,26 @@ class EventResult : MonoBehaviour
                 text.text = evt.option2FailDescription;
                 this.result.text = evt.option2FailResult;
             }
+        }
+        else
+        {
+            return;
+        }
+
+        if (InGameManager.Instance != null && InGameManager.Instance.EventManager != null)
+        {
+            InGameManager.Instance.EventManager.RecordChoice(evt.eventID, result, succeeded);
+            StartCoroutine(AutoSaveChoiceResult());
+        }
+    }
+
+    private static IEnumerator AutoSaveChoiceResult()
+    {
+        // 엔딩 전환은 같은 프레임에 이 오브젝트를 파괴하므로 완료 세이브를 다시 만들지 않는다.
+        yield return null;
+        if (SaveManager.Instance != null)
+        {
+            SaveManager.Instance.AutoSave();
         }
     }
 }


### PR DESCRIPTION
## 📌 PR 제목

Feature/event: 이벤트 시스템 잔여 구현 및 공작 연동 완성

---

## 🧩 변경 사항 요약 (Summary)

- 이벤트 37개 중 태양만세 엔딩을 제외한 36개 이벤트 구현
- 이벤트 선택 결과와 지속 효과의 세이브/로드 지원
- 공작 피해 증가·경건함 비용 면제·최소 체력 유지 등 이벤트 효과를 실제 게임 시스템에 연결
- 이벤트 선행 조건, 충돌 조건, 가중치 및 엔딩 분기 정비

---

## 🔧 주요 변경 내용 (Details)

- [x] 기능 추가:
  - 이벤트 선택지 번호와 성공/실패 결과 저장 및 복원
  - 이벤트 등장 횟수, 후보별 공작 피해 보너스, 콘클라베 지속 효과 저장
  - E21100/E31000 후보별 공작 피해 증가 적용
  - E40500 기도·연설 후 남은 시간 추가 감소
  - E40600 다음 플레이어 기도/연설 1회 확정 성공
  - E50100 기둥 근접 여부에 따른 성공 확률 변경
  - E50600 공작 경건함 비용 면제 및 대표 후보 최소 체력 유지
  - 이벤트별 엔딩 분기 연결
  - 이벤트 선택 직후 자동 저장

- [x] 버그 수정:
  - 이벤트 선택 결과가 로드 후 사라져 후속 스토리 분기가 끊기던 문제 수정
  - E30000 성공/실패 효과가 뒤바뀐 문제 수정
  - E11100 런타임 이벤트가 실제 에셋 정의를 사용하지 않던 문제 수정
  - E31100 최대 등장 횟수 수정
  - 이벤트 발생 전에 자격 조건을 검사하지 않던 선택 로직 수정
  - E50600 효과가 전체 21명이 아닌 플레이어와 대표 후보 3명에게 적용되도록 수정

- [x] 리팩토링:
  - 34개 공작의 비용 차감을 공통 비용 API로 통합
  - 경건함 비용과 체력 비용을 명시적으로 구분
  - 공작 전용 HP 변경 경로 추가
  - 최소 체력 1 효과를 출처별로 관리하도록 변경
  - 이벤트 선택 결과 기록을 공통 UI 경로로 통합

- [ ] 성능 개선:
- [ ] 문서 수정:

---

## 🎮 관련 시스템 / 파일

- `Assets/Event/Scripts/Event.cs`
- `Assets/Event/Scripts/EventManager.cs`
- `Assets/Event/EventsScripts/`
- `Assets/Event/SO/E31100.asset`
- `Assets/Plot/Scripts/Plot.cs`
- `Assets/Plot/Scripts/PlotManager.cs`
- `Assets/Plot/Scripts/Plot List/`
- `Assets/Cardinal/Scripts/Cardinal.cs`
- `Assets/Core/Scripts/SaveModel.cs`
- `Assets/UI/Scripts/InGame/PlotUI.cs`
- `Assets/UI/Scripts/InGame/StatsUI/EventUI/EventResult.cs`

---

## ⚠️ 주의 사항 / 리뷰 포인트

- E21100과 E31000의 공작 피해 보너스는 현재 콘클라베까지만 유지되며, 같은 후보에게 다시 설정되면 기존 값이 덮어써집니다.
- P033 지연 피해는 실제 피해 발생 시점의 이벤트 보너스를 기준으로 계산하므로 다음 콘클라베에서는 이전 보너스가 적용되지 않습니다.
- E31000 선택지 2는 효과 컬럼 기준으로 후보 3 피해 `+20`을 적용하며 성공 확률은 100%입니다. 기존 실패 텍스트와 실패 효과는 사용되지 않습니다.
- E50600은 경건함 비용만 면제합니다. 경건함 실행 조건, 공작 자체의 경건함 감소 효과 및 P022 체력 비용은 유지됩니다.
- E50600 활성 중에도 UI 비용 텍스트는 기존 비용으로 표시됩니다.
- 공작 실행 실패 시 슬롯 소모와 공작 사용 기록은 기존 동작을 유지합니다.
- 태양만세 엔딩은 기획 요청에 따라 TODO 주석만 남기고 구현하지 않았습니다.
- 공작 34개의 비용 경로가 공통 API로 변경되었으므로 경건함 비용 공작과 P022 체력 비용을 중점적으로 리뷰해 주세요.

---

## ✅ 체크리스트

- [x] C# 프로젝트 빌드 성공
- [x] 컴파일 오류 없음
- [x] 변경 코드 `git diff --check` 통과
- [x] 불필요한 신규 로그 없음
- [x] 코드 스타일 및 기존 구조 준수
- [x] 이벤트 비활성 상태에서 기존 공작 비용·피해 동작 유지 확인
- [ ] Unity Play Mode 전체 이벤트 수동 회귀 테스트
- [ ] 기존 UI 미사용 필드 경고 4건 정리

---

## 💬 추가 코멘트

- 현재 이벤트 진행도는 총 37개 중 36개 완료입니다.
- 남은 항목은 의도적으로 보류한 태양만세 엔딩뿐입니다.
- `Assembly-CSharp.csproj` 빌드 기준 오류 0개이며, 기존 UI 미사용 필드 경고 4개가 남아 있습니다.